### PR TITLE
Don't log this common error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -214,9 +214,6 @@ func main() {
 		// Parse channel name from path.
 		name, err := parseChannelName(r.URL.Path)
 		if err != nil {
-			if hub != nil {
-				hub.CaptureException(err)
-			}
 			slog.Error("Could not parse channel name")			
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
Don't log bad channel names. This is usually caused by scanners and scammers.